### PR TITLE
Add `name` attribute to input tag

### DIFF
--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -64,6 +64,7 @@ const Input = forwardRef<HTMLInputElement>((_props, ref) => {
 		<input
 			ref={ref}
 			type="text"
+			name="date"
 			id="date"
 			className={twMerge(
 				"pl-9 pr-2.5 py-2.5 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500",


### PR DESCRIPTION
This will allow easier retrieval of the datepicker's value on form submission via `FormData.get('date')`.