### PR TITLE
Added Flowbite references in the README file + license reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Tailwind-datepicker-react
 
-A Tailwindcss/Flowbite datepicker component built as a React component with types
+A Tailwindcss/Flowbite datepicker component built as a React component with types based on the [original datepicker from Flowbite](https://flowbite.com/docs/plugins/datepicker/). This component can also be used as a plugin using the [Flowbite React](https://github.com/themesberg/flowbite-react) library.
 
-Date logic from [VanillaJS-datepicker](https://github.com/mymth/vanillajs-datepicker)
+Date logic from [VanillaJS-datepicker](https://github.com/mymth/vanillajs-datepicker).
 
 ## [Demo](https://omikkel.github.io/tailwind-datepicker-react/)
 
@@ -196,3 +196,7 @@ const DemoComponent = () => {
 
 - prev: () => ReactNode | JSX.Element
 - next: () => ReactNode | JSX.Element
+
+### License
+
+This project is open-source under the [MIT License](https://github.com/OMikkel/tailwind-datepicker-react/blob/master/LICENSE.md).


### PR DESCRIPTION
Hey @OMikkel,

I've added reference to the original datepicker style (for those who want the vanilla JS version) & the Flowbite React library which should play quite well with this datepicker plugin - considering the styles.

I also added a reference to the license file inside the README to make it clear to everyone.

Cheers,
Zoltan