### PR TITLE
[BUGFIX] Objects are not valid as a React child (found object with keys {children} )

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const options = {
 		selected: "",
 	},
 	icons: {
-		// () => ReactNode | JSX.Element
+		// () => ReactElement | JSX.Element
 		prev: () => <span>Previous</span>,
 		next: () => <span>Next</span>,
 	},
@@ -78,7 +78,7 @@ const options = {
 }
 
 const DemoComponent = () => {
-	const [show, setShow] = useState < boolean > false
+	const [show, setShow] = useState <boolean>(false)
 	const handleChange = (selectedDate: Date) => {
 		console.log(selectedDate)
 	}
@@ -115,7 +115,7 @@ const options = {
 		inputIcon: "",
 		selected: "",
 	},
-    icons: { // () => ReactNode | JSX.Element
+    icons: { // () => ReactElement | JSX.Element
         prev: () => <span>Previous</span>,
         next: () => <span>Next</span>,
     },
@@ -159,7 +159,7 @@ const DemoComponent = () => {
 
 ### DatePicker Props
 
-- children?: ReactNode
+- children?: ReactElement
 - options?: [IOptions](###IOptions)
 - onChange?: (date: Date) => void
 - show: boolean
@@ -194,5 +194,5 @@ const DemoComponent = () => {
 
 ### IIcons
 
-- prev: () => ReactNode | JSX.Element
-- next: () => ReactNode | JSX.Element
+- prev: () => ReactElement | JSX.Element
+- next: () => ReactElement | JSX.Element

--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef, ReactNode, useContext, useEffect, useRef } from "react"
+import React, { forwardRef, ReactElement, useContext, useEffect, useRef } from "react"
 import { twMerge } from "tailwind-merge"
 import { IOptions } from "../Options"
 import DatePickerPopup from "./DatePickerPopup"
 import DatePickerProvider, { DatePickerContext } from "./DatePickerProvider"
 
 export interface IDatePickerProps {
-	children?: ReactNode
+	children?: ReactElement
 	options?: IOptions
 	onChange?: (date: Date) => void
 	show: boolean
@@ -21,7 +21,7 @@ const DatePicker = ({ children, options, onChange, classNames, show, setShow }: 
 	</div>
 )
 
-const DatePickerMain = ({ children }: { children: ReactNode }) => {
+const DatePickerMain = ({ children }: { children?: ReactElement }) => {
 	const { setShow, show } = useContext(DatePickerContext)
 	const InputRef = useRef<HTMLInputElement>(null)
 	const DatePickerRef = useRef<HTMLDivElement>(null)
@@ -44,7 +44,7 @@ const DatePickerMain = ({ children }: { children: ReactNode }) => {
 	return (
 		<>
 			{children ? (
-				{ children }
+				{ ...children }
 			) : (
 				<div className="relative">
 					<div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">

--- a/src/Components/DatePickerProvider.tsx
+++ b/src/Components/DatePickerProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Dispatch, ReactNode, SetStateAction, useState } from "react"
+import React, { createContext, Dispatch, ReactElement, SetStateAction, useState } from "react"
 import { IOptions } from "../Options"
 import defaultOptions from "../Options"
 import { getFormattedDate as formatDate } from "../Utils/date"
@@ -36,7 +36,7 @@ export const DatePickerContext = createContext<IDatePickerContext>({
 })
 
 interface IDatePickerProviderProps {
-	children: ReactNode
+	children: ReactElement
 	options?: IOptions
 	onChange?: (date: Date) => void
 	show: boolean

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import { ReactElement } from "react"
 
 interface ITheme {
 	background: string
@@ -13,8 +13,8 @@ interface ITheme {
 }
 
 interface IIcons {
-	prev: () => ReactNode | JSX.Element
-	next: () => ReactNode | JSX.Element
+	prev: () => ReactElement | JSX.Element
+	next: () => ReactElement | JSX.Element
 }
 
 export interface IOptions {


### PR DESCRIPTION
**Problem**
When introducing children to DatePicker, Next.js throws the following runtime error

![children-bug](https://user-images.githubusercontent.com/32182942/215356554-b238fdf4-a1c1-4ad9-8aa1-e99bd0541fc0.png)

**How to reproduce**
- Run the demo app provided in this repository
- Update pages>index.tsx so that the DatePicker component is not self-closing but has children 
- A simple \<div/> is sufficient to get the bug. Like this: 
```js
<DatePicker show={show} setShow={(state) => setShow(state)} options={options} classNames="absolute" >
	<div/>
</DatePicker>
```
**Root cause**
The `ReactNode` as the type of `children` prop was too broad. This caused `children` to be identified as an object/ any type making React unable to render it. [This was fixed in React 18.](https://solverfox.dev/writing/no-implicit-children/) 

**Solution**
Narrow down the type of `children` to `ReactElement` and destructure it when used.

**Extra**
Code provided in README.md was missing parenthesis on `useState<boolean>(false)` call, thus disabling blind copy-pasting. That was fixed too. 

**Changes made**
- Update usages of ReactNode with ReactElement
- Add missing parenthesis on README.md
- Update DatePicker children rendering logic