### PR TITLE
[ADD] `selectedDateState` as optional prop for `DatePicker` to ease implementation when `selectedDateState` is handled by ancestor

### DIFF
--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -10,12 +10,13 @@ export interface IDatePickerProps {
 	onChange?: (date: Date) => void
 	show: boolean
 	setShow: (show: boolean) => void
-	classNames?: string
+	classNames?: string,
+	selectedDateState?: [Date, (date: Date) => void]
 }
 
-const DatePicker = ({ children, options, onChange, classNames, show, setShow }: IDatePickerProps) => (
+const DatePicker = ({ children, options, onChange, classNames, show, setShow, selectedDateState }: IDatePickerProps) => (
 	<div className={twMerge("w-full", classNames)}>
-		<DatePickerProvider options={options} onChange={onChange} show={show} setShow={setShow}>
+		<DatePickerProvider options={options} onChange={onChange} show={show} setShow={setShow} selectedDateState={selectedDateState}>
 			<DatePickerMain>{children}</DatePickerMain>
 		</DatePickerProvider>
 	</div>

--- a/src/Components/DatePickerProvider.tsx
+++ b/src/Components/DatePickerProvider.tsx
@@ -40,13 +40,14 @@ interface IDatePickerProviderProps {
 	options?: IOptions
 	onChange?: (date: Date) => void
 	show: boolean
-	setShow: (show: boolean) => void
+	setShow: (show: boolean) => void,
+	selectedDateState?: [Date, (date: Date) => void]
 }
 
-const DatePickerProvider = ({ children, options: customOptions, onChange, show, setShow }: IDatePickerProviderProps) => {
+const DatePickerProvider = ({ children, options: customOptions, onChange, show, setShow, selectedDateState }: IDatePickerProviderProps) => {
 	const options = { ...defaultOptions, ...customOptions }
 	const [view, setView] = useState<Views>("days")
-	const [selectedDate, setSelectedDate] = useState<Date>(options?.defaultDate || new Date())
+	const [selectedDate, setSelectedDate] = selectedDateState || useState<Date>(options?.defaultDate || new Date())
 	const [showSelectedDate, setShowSelectedDate] = useState<boolean>(true)
 	const selectedMonth = selectedDate.getMonth()
 	const selectedYear = selectedDate.getFullYear()


### PR DESCRIPTION
Add `selectedDateState` prop to `DatePicker` and `DatePickerProvider` to handle `selectedDate` state from outside `DatePicker` component.

The absence of `selectedDateState` keeps the previously defined behavior, it's entirely optional. 

This allows an easier implementation when `selectedDateState` is being handled by an ancestor component of the `DatePicker`. *For instance, you have a form with a `Date` field and you need to provide the initial value based on fetched data. Putting that `Date` inside `options` prop can get messy and lead to unnecessary rebuilds or inconsistencies.*

