### PR TITLE
Add new options

### DIFF
--- a/src/Components/Buttons.tsx
+++ b/src/Components/Buttons.tsx
@@ -92,7 +92,7 @@ export const ButtonToday = () => {
 				setView("days")
 			}}
 		>
-			Today
+			{options?.todayBtnText}
 		</button>
 	)
 }
@@ -108,7 +108,7 @@ export const ButtonClear = () => {
 			)}
 			onClick={() => setShowSelectedDate(false)}
 		>
-			Clear
+			{options?.clearBtnText}
 		</button>
 	)
 }

--- a/src/Components/Views/Days.tsx
+++ b/src/Components/Views/Days.tsx
@@ -8,12 +8,11 @@ interface IDaysProps {
 }
 
 const Days = ({ start }: IDaysProps) => {
-	const weekDays: string[] = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
 	const { selectedDate, changeSelectedDate, showSelectedDate, getFormattedDate, options } = useContext(DatePickerContext)
 	return (
 		<>
 			<div className="grid grid-cols-7 mb-1">
-				{weekDays.map((day, index) => (
+				{options.weekDays?.map((day, index) => (
 					<span key={index} className="h-6 text-sm font-medium leading-6 text-center text-gray-500 dow dark:text-gray-400">
 						{day}
 					</span>

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -21,7 +21,9 @@ export interface IOptions {
 	title?: string
 	autoHide?: boolean
 	todayBtn?: boolean
+	todayBtnText?: string
 	clearBtn?: boolean
+	clearBtnText?: string
 	maxDate?: Date
 	minDate?: Date
 	theme?: ITheme
@@ -29,12 +31,15 @@ export interface IOptions {
 	datepickerClassNames?: string
 	defaultDate?: Date
 	language?: string
+	weekDays?: string[]
 }
 
 const options: IOptions = {
 	autoHide: true,
 	todayBtn: true,
 	clearBtn: true,
+	todayBtnText: "Today",
+	clearBtnText: "Clear",
 	theme: {
 		background: "",
 		todayBtn: "",
@@ -49,6 +54,7 @@ const options: IOptions = {
 	datepickerClassNames: "",
 	defaultDate: new Date(),
 	language: "en",
+	weekDays: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
 }
 
 export default options


### PR DESCRIPTION
The `todayBtnText` and `clearBtnText` properties allow the user to customize the text displayed on the "Today" and "Clear" buttons, respectively. This can be useful if the default text is not appropriate for the user's specific use case.

The `weekDays` property allows the user to customize the labels for the days of the week displayed in the datepicker. This is particularly useful for internationalization and localization purposes, as different languages may have different labels for the days of the week.

Overall, these changes provide greater flexibility and customization options for users of the library. The new properties are optional, so users who do not need to customize these aspects of the datepicker can continue to use the library without any changes.