### PR TITLE
fix: children was converted to obj before render

### DIFF
--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -45,7 +45,7 @@ const DatePickerMain = ({ children }: { children?: ReactElement }) => {
 	return (
 		<>
 			{children ? (
-				{ children }
+				children
 			) : (
 				<div className="relative">
 					<div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">


### PR DESCRIPTION
I discovered that while trying Advanced - Custom input field example, the children was converted to object before rendering causing error. I fixed it removing curly braces around children node.