### PR TITLE
fix: ignore type error (Intl.Locale)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "tailwind-datepicker-react",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tailwind-datepicker-react",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "A tailwindcss/flowbite datepicker component built as a react component with types",
 	"main": "dist/index.js",
 	"types": "types/index.d.ts",

--- a/src/Components/DatePickerPopup.tsx
+++ b/src/Components/DatePickerPopup.tsx
@@ -12,6 +12,7 @@ const DatePickerPopup = forwardRef<HTMLDivElement>((_props, ref: ForwardedRef<HT
 	const { selectedMonth, selectedYear, view, options } = useContext(DatePickerContext)
 	
 	const language = options?.language ? options?.language : "en";
+    // @ts-ignore
 	const locale = new Intl.Locale(language);
 	
 	const weekStart = (locale?.weekInfo?.firstDay || 1);


### PR DESCRIPTION
Ignore type error where typescript would not acknowledge property Locale does exist on the class Intl

Fixes: #19 