### PR TITLE
fix: next and previous buttons should let you see the min and max date

### DIFF
--- a/src/Components/DatePickerProvider.tsx
+++ b/src/Components/DatePickerProvider.tsx
@@ -45,7 +45,6 @@ interface IDatePickerProviderProps {
 }
 
 const DatePickerProvider = ({ children, options: customOptions, onChange, show, setShow, selectedDateState }: IDatePickerProviderProps) => {
-
 	const options = { ...defaultOptions, ...customOptions }
 	const [view, setView] = useState<Views>("days")
 	const [selectedDate, setSelectedDate] = selectedDateState || useState<Date>(options?.defaultDate || new Date())
@@ -54,10 +53,39 @@ const DatePickerProvider = ({ children, options: customOptions, onChange, show, 
 	const selectedYear = selectedDate.getFullYear()
 
 	const changeSelectedDate = (action: "prev" | "next" | "date" | "today", date: Date) => {
-		if (options?.maxDate && date > options.maxDate) return
-		if (options?.minDate && date < options.minDate) return
+		let compareDate = new Date(0)
+		if (action === "today" || action === "date") {
+			compareDate = date
+		} else {
+			switch (view) {
+				case "days":
+					if (action === "prev") compareDate.setFullYear(date.getFullYear(), date.getMonth() + 1, 0) // Last day of the month
+					if (action === "next") compareDate.setFullYear(date.getFullYear(), date.getMonth(), 1) // First day of the month
+					break
+				case "months":
+					if (action === "prev") compareDate.setFullYear(date.getFullYear(), 12, 0) // December 31st
+					if (action === "next") compareDate.setFullYear(date.getFullYear(), 0, 1) // January 1st
+					break
+				case "years":
+					if (action === "prev") compareDate.setFullYear(Math.floor(date.getFullYear() / 10) * 10 + 9, 12, 0) // December 31st, ???9
+					if (action === "next") compareDate.setFullYear(Math.floor(date.getFullYear() / 10) * 10, 0, 1) // January 1st, ???0
+					break
+				case "decades":
+					if (action === "prev") compareDate.setFullYear(Math.floor(date.getFullYear() / 100) * 100 + 99, 12, 0) // December 31st, ??99
+					if (action === "next") compareDate.setFullYear(Math.floor(date.getFullYear() / 100) * 100, 0, 1) // January 1st, ??00
+					break
+			}
+		}
+		if (options?.maxDate && compareDate >= options.maxDate) return
+		if (options?.minDate && compareDate <= options.minDate) return
 		if (options?.disabledDates && options.disabledDates.indexOf(date) >= 0) return
-		setSelectedDate(date)
+		if (options?.maxDate && date > options.maxDate) {
+			setSelectedDate(new Date(options.maxDate.toString()))
+		} else if (options?.minDate && date < options.minDate) {
+			setSelectedDate(new Date(options.minDate.toString()))
+		} else {
+			setSelectedDate(date)
+		}
 		setShowSelectedDate(true)
 		if (options?.autoHide && view === "days" && action === "date") setShow(false)
 		if (onChange) onChange(date)


### PR DESCRIPTION
## What does this change do?

This change makes it so that if the developer has specified a minDate or maxDate, the calendar can return to the month/year/decade that date is specified in. Without this change, if a user has set a minDate of October 20th and the current date selected is November 1st, the user can not go back to October to select any dates even though there are valid dates available. The user would have to know that they need to select a day of the month higher than 20 before being able to look at October.

