### PR TITLE
fix: you should not be able to go further than the last date

### DIFF
--- a/src/Utils/date.ts
+++ b/src/Utils/date.ts
@@ -45,24 +45,25 @@ export const getFormattedDate = (language: string, date: Date | number, options?
 		month: "long",
 		year: "numeric",
 	}
-	
+
 	if (options) defaultOptions = options
 
 	return new Intl.DateTimeFormat(language, defaultOptions).format(date)
 }
 
 export const goToPrevNext = (view: Views, date: Date, direction: number): number => {
+	const newDate = new Date(date.toString())
 	switch (view) {
 		case "days":
-			return addMonths(date, direction)
+			return addMonths(newDate, direction)
 		case "months":
-			return addYears(date, direction)
+			return addYears(newDate, direction)
 		case "years":
-			return addYears(date, direction * 10)
+			return addYears(newDate, direction * 10)
 		case "decades":
-			return addYears(date, direction * 100)
+			return addYears(newDate, direction * 100)
 		default:
-			return addYears(date, direction * 10)
+			return addYears(newDate, direction * 10)
 	}
 }
 


### PR DESCRIPTION
## What does this change do?

If the developer has specified a minDate and the user arrives at the last possible page but continues to hit the previous button, the date will continue to be modified and will therefore put them in a "negative" state, so that when they hit the next button, the calendar does not move to the next month.

The same is true for a maxDate and the next button.

This change fixes it so that continuing to push the previous button will not put the user into a "negative" state.

## Why was this happening?

The date being passed into the `goToPrevNext` function is a reference to the state of the calendar. Since it is only a reference, when we add time to it, it is actually mutating the state in a way that is invisible to react. This causes the date to change without calling the setState function and without changing the reference. Not only is changing the state at this moment not wanted, but React is also unaware of the change and does not know to rerender.

To fix this, we need to clone the date so that the state's version is not being mutated.