### PR TITLE
Added anchor option to date picker to prevent overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ const DemoComponent = () => {
 
 ### IOptions
 
+- anchor?: "auto"|"left"|"right" - Default: `auto`
 - title?: string - Default: `disabled`
 - autoHide?: boolean - Default: `true`
 - todayBtn?: boolean - Default: `true`

--- a/src/Components/DatePicker.tsx
+++ b/src/Components/DatePicker.tsx
@@ -17,7 +17,7 @@ export interface IDatePickerProps {
 }
 
 const DatePicker = ({ value, children, options, onChange, classNames, show, setShow, selectedDateState }: IDatePickerProps) => (
-	<div className={twMerge("w-full", classNames)}>
+	<div className={twMerge("w-full relative", classNames)}>
 		<DatePickerProvider options={options} onChange={onChange} show={show} setShow={setShow} selectedDateState={selectedDateState}>
 			<DatePickerMain value={value} options={options}>
 				{children}

--- a/src/Components/DatePickerPopup.tsx
+++ b/src/Components/DatePickerPopup.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef, useContext } from "react"
+import React, {ForwardedRef, forwardRef, useContext, useEffect, useState} from "react"
 import { twMerge } from "tailwind-merge"
 import { dayOfTheWeekOf, firstDateOfMonth } from "../Utils/date"
 import { ButtonClear, ButtonNextMonth, ButtonPrevMonth, ButtonSelectMonth, ButtonToday } from "./Buttons"
@@ -18,9 +18,36 @@ const DatePickerPopup = forwardRef<HTMLDivElement>((_props, ref: ForwardedRef<HT
 	const weekStart = (locale?.weekInfo?.firstDay || 1);
 	const firstOfMonth = firstDateOfMonth(selectedYear, selectedMonth, 1)
 	const start = dayOfTheWeekOf(firstOfMonth, weekStart, weekStart);
+
+
+	const [leftAnchor,setLeftAnchor] = useState(options.anchor !== "right")
+
+	useEffect(()  => {
+		setLeftAnchor(options.anchor !== "right")
+		if (options.anchor !== "auto"){
+			return;
+		}
+		// @ts-ignore
+		const  _ref: HTMLDivElement = ref.current;
+		if (!_ref){
+			return;
+		}
+
+		const resize = () => {
+			const rect = _ref.getBoundingClientRect();
+			const screenWidth = window.innerWidth;
+
+			setLeftAnchor(rect.right <= screenWidth)
+		}
+		resize();
+		window.addEventListener("resize",resize);
+		return  () => {
+			window.removeEventListener("resize",resize)
+		}
+	},[ref,options.anchor])
 	
 	return (
-		<div ref={ref} className={twMerge("absolute z-50 block pt-2 top-10", options?.datepickerClassNames)}>
+		<div ref={ref} className={twMerge("absolute z-50 block pt-2 top-10"+(leftAnchor ? "" : "  right-0"), options?.datepickerClassNames)}>
 			<div className={twMerge("inline-block p-4 bg-white rounded-lg shadow-lg dark:bg-gray-700", options?.theme?.background)}>
 				<div>
 					{options?.title && <div className={twMerge("px-2 py-3 font-semibold text-center text-gray-900 dark:text-white", options?.theme?.text)}>{options?.title}</div>}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -18,6 +18,7 @@ interface IIcons {
 }
 
 export interface IOptions {
+	anchor: "left"|"right"|"auto",
 	title?: string
 	autoHide?: boolean
 	todayBtn?: boolean
@@ -40,6 +41,7 @@ export interface IOptions {
 }
 
 const options: IOptions = {
+	anchor: "auto",
 	autoHide: true,
 	todayBtn: true,
 	clearBtn: true,

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -18,7 +18,7 @@ interface IIcons {
 }
 
 export interface IOptions {
-	anchor: "left"|"right"|"auto",
+	anchor?: "left"|"right"|"auto",
 	title?: string
 	autoHide?: boolean
 	todayBtn?: boolean


### PR DESCRIPTION
### Summary
This pull request introduces a new anchor option to the date picker component, allowing better positioning control when the popup might overflow the user's screen.

### Changes Introduced
Added an anchor prop with the following options:
- "left": Anchors the date picker popup to the left of the input element.
- "right": Anchors the date picker popup to the right of the input element.
- "auto" (default): Automatically adjusts the position to prevent overflow. The date picker popup will first anchor to the left of the input element. Note: There might be a slight "flash" when the component first appears outside the screen due to the delay of the useEffect hook.

### Why This Change?
Previously, the date picker could overflow the viewport if the input element was near the right edge of the screen. This enhancement improves the user experience by ensuring the popup remains fully visible within the viewport.

### Potential Improvements
Future enhancements could include:
- Adding an offset option to allow better spacing adjustments.
- Using CSS translations instead of repositioning to avoid layout shifts and improve visual appearance.

### Documentation
Updated the README to include details about the new anchor option.